### PR TITLE
fix: when I create an NFT

### DIFF
--- a/src/collections/repositories/collection.repository.ts
+++ b/src/collections/repositories/collection.repository.ts
@@ -47,9 +47,9 @@ export class CollectionRepository extends Repository<Collection> {
 
     return data;
   }
-  async findByName(name: string): Promise<Collection | undefined> {
+  async findByName(name: string, account: Account): Promise<Collection | undefined> {
     const data = await this.findOne({
-      where: { name },
+      where: { name, owner: new Account(account.accountId) },
     });
 
     if (!data) return;

--- a/src/items/services/item.service.ts
+++ b/src/items/services/item.service.ts
@@ -85,7 +85,10 @@ export class ItemService {
       return this.collectionRepository.getDefaultCollection();
     }
 
-    const collection = await this.collectionRepository.findByName(itemRequest.collection.name);
+    const collection = await this.collectionRepository.findByName(
+      itemRequest.collection.name,
+      account
+    );
 
     if (collection) return collection;
 


### PR DESCRIPTION
When I create an NFT, assigning it a Collection that already exists, it's added to it, instead creating a new one